### PR TITLE
version 0.2.1+3: Allow "analyzer" versions up to 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1+3
+
+- Allow "analyzer" versions up to 0.42.0
+
 ## 0.2.1+2
 
 - Make sure no `dependency_overrides` are used in the example project

--- a/sum_types_generator/pubspec.yaml
+++ b/sum_types_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sum_types_generator
 description: sum_types and sum_types_generator packages together define a code generator enabling sum-types in Dart.
-version: 0.2.1+2
+version: 0.2.1+3
 homepage: https://github.com/werediver/sum-types-dart
 author: Raman Fedaseyeu <raman.fedaseyeu@gmail.com>
 
@@ -11,7 +11,7 @@ dependencies:
   sum_types: ^0.2.0
   meta: ^1.1.0
   build: ^1.1.0
-  analyzer: '>=0.36.4 <0.40.0'
+  analyzer: '>=0.36.4 <0.42.0'
   source_gen: ^0.9.2
 
 dev_dependencies:


### PR DESCRIPTION
It seems that they are compatible and other packages (like https://github.com/spkersten/dart_functional_data) require a newer `analyzer` version.