### PR TITLE
Support types visible through qualified imports (`import … as …;`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- Support types visible through qualified imports (`import … as …;`)
+
 ## 0.3.3
 
 - Fix a few warnings in the generated code

--- a/sum_types/pubspec.yaml
+++ b/sum_types/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sum_types
 description: sum_types and sum_types_generator packages together define a code generator enabling sum-types in Dart.
-version: 0.3.3
+version: 0.3.4
 homepage: https://github.com/werediver/sum-types-dart
 
 environment:

--- a/sum_types_generator/pubspec.yaml
+++ b/sum_types_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sum_types_generator
 description: sum_types and sum_types_generator packages together define a code generator enabling sum-types in Dart.
-version: 0.3.3
+version: 0.3.4
 homepage: https://github.com/werediver/sum-types-dart
 
 environment:

--- a/sum_types_generator/pubspec.yaml
+++ b/sum_types_generator/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   analyzer: '>=2.0.0 <5.0.0'
   build: ^2.0.1
+  collection: ^1.17.0
   meta: ^1.1.0
   source_gen: ^1.0.0
   sum_types: ^0.3.0


### PR DESCRIPTION
Resolves #3 